### PR TITLE
Add response object to protocol errors to facilitate improved logging

### DIFF
--- a/src/Net/Http/Client.php
+++ b/src/Net/Http/Client.php
@@ -281,9 +281,9 @@ class Net_Http_Client {
 		if ($this->failOnError) {
 			$status = $this->getStatus();
 			if ($status >= 400 && $status <= 499) {
-				throw new Net_Http_ClientError($this->getStatusMessage(), $status);
+				throw new Net_Http_ClientError($this->getStatusMessage(), $status, $this->getResponse());
 			} elseif ($status >= 500 && $status <= 599) {
-				throw new Net_Http_ServerError($this->getStatusMessage(), $status);
+				throw new Net_Http_ServerError($this->getStatusMessage(), $status, $this->getResponse());
 			}
 		}
 		if ($this->followLocation) {

--- a/src/Net/Http/ProtocolError.php
+++ b/src/Net/Http/ProtocolError.php
@@ -12,4 +12,45 @@
  *
  * See {@link Net_Http_ClientError} and {@link Net_Http_ServerError}
  */
-abstract class Net_Http_ProtocolError extends Net_Http_Exception {}
+abstract class Net_Http_ProtocolError extends Net_Http_Exception
+{
+	/**
+	 * @var Net_Http_Response
+	 */
+	private $response;
+	
+	/**
+	 * @param string $message
+	 * @param int $status
+	 * @param Net_Http_Response $response
+	 */	
+	public function __construct($message, $status, $response)
+	{
+		$this->response = $response;
+		parent::__construct($message, $status);
+	}
+	
+	/**
+	 * @return int
+	 */
+	public function getStatus()
+	{
+		return $this->getCode();
+	}
+	
+	/**
+	 * @return Net_Http_Response
+	 */
+	public function getResponse()
+	{
+		return $this->response;
+	}
+	
+	/**
+	 * @return string
+	 */
+	public function getBody()
+	{
+		return $this->response->getBody();
+	}
+}

--- a/src/Net/Http/Response.php
+++ b/src/Net/Http/Response.php
@@ -16,7 +16,7 @@
 final class Net_Http_Response
 {
 	private $status;
-	private $headers;
+	private $message;
 	private $body;
 
 	public function __construct($status, $headers, $body='')

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -111,6 +111,8 @@ class ClientTest extends HttpTestCase
 		} catch(Net_Http_ClientError $e) {
 			$this->assertContains('Not Found', $e->getMessage());
 			$this->assertEquals(404, $e->getCode());
+			$this->assertEquals(404, $e->getResponse()->getStatus());
+			$this->assertContains('Resource Not Found', $e->getBody());
 		}
 	}
 
@@ -124,6 +126,8 @@ class ClientTest extends HttpTestCase
 		} catch(Net_Http_ServerError $e) {
 			$this->assertContains('Internal Server Error', $e->getMessage());
 			$this->assertEquals(500, $e->getCode());
+			$this->assertEquals(500, $e->getResponse()->getStatus());
+			$this->assertContains('The Server Exploded', $e->getBody());
 		}
 	}
 }

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright (c) 2011, BigCommerce Pty. Ltd. <http://www.bigcommerce.com>
+ * All rights reserved.
+ * 
+ * This library is free software; refer to the terms in the LICENSE file found
+ * with this source code for details about modification and redistribution.
+ */
+
+class ResponseTest extends PHPUnit_Framework_TestCase {
+
+	public function testObjectConstruction()
+	{
+		$response = new Net_Http_Response(200, array("Content-Type"=>"text/plain"), "hello world");
+		
+		$this->assertTrue($response->isOk());
+		$this->assertEquals("text/plain", $response->getHeader("Content-Type"));
+		$this->assertEquals("hello world", $response->getBody());
+	}
+
+}


### PR DESCRIPTION
Can now catch an HTTP exception and `getStatus()`, `getBody()`, and `getResponse()` on it.
