### PR TITLE
Explicitly close cURL connections at the end of each request

### DIFF
--- a/src/Net/Http/Client.php
+++ b/src/Net/Http/Client.php
@@ -124,7 +124,7 @@ class Net_Http_Client {
 		}
 
 		if ($options = Net_Http::getOptions()) {
-			$this->options = array_merge($this->options, $options);
+			$this->options = array_replace($this->options, $options);
 		}
 	}
 
@@ -558,5 +558,15 @@ class Net_Http_Client {
 	public function getInfo()
 	{
 		return $this->responseInfo;
+	}
+
+	/**
+	 * Return an array of cURL options
+	 *
+	 * @return array
+	 */
+	public function getOptions()
+	{
+		return $this->options;
 	}
 }

--- a/test/OptionsTest.php
+++ b/test/OptionsTest.php
@@ -24,6 +24,30 @@ class OptionsTest extends HttpTestCase {
 		}
 	}
 
+	public function testMergesHttpOptions()
+	{
+		Net_Http::setTimeout(1000);
+
+		$client = new Net_Http_Client;
+		$opts   = $client->getOptions();
+
+		$this->assertArrayHasKey(CURLOPT_TIMEOUT, $opts);
+		$this->assertEquals(1000, $opts[CURLOPT_TIMEOUT]);
+	}
+
+	public function testClientOptionsOverrideHttpOptions()
+	{
+		Net_Http::setTimeout(1000);
+
+		$client = new Net_Http_Client;
+		$client->setTimeout(2000);
+
+		$opts = $client->getOptions();
+
+		$this->assertArrayHasKey(CURLOPT_TIMEOUT, $opts);
+		$this->assertEquals(2000, $opts[CURLOPT_TIMEOUT]);
+	}
+
 	public function tearDown()
 	{
 		Net_Http::clearOptions();


### PR DESCRIPTION
We had an incident over the weekend due to a long running process which utilized this library for HTTP requests to our DNS service. Due to how the library closes cURL connections (`__destruct`) and how PHP GC works (it doesn't), we ended up with a lot of open file descriptors which caused the long running process to hit the limit on the number of open files. Bad things happened.

This change explicitly closes the cURL connection after each request, and initializes a new one for subsequent requests.

I'm after some feedback on if this is the right way to go about these changes before a blind merge, and also a sanity check as this is a fairly critical library for many of our applications.
