### PR TITLE
chore(platform): PHPMNT-177 Add PHP 8.3 and 8.4 to CircleCI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs_default: &jobs_default
     php-version: << matrix.php-version >>
   matrix:
     parameters:
-      php-version: [ "8.1", "8.2" ]
+      php-version: [ "8.1", "8.2", "8.3", "8.4" ]
 
 
 workflows:


### PR DESCRIPTION
Jira: [PHPMNT-177](https://bigcommercecloud.atlassian.net/browse/PHPMNT-177)

## What/Why?
Add PHP 8.3 and 8.4 to CircleCI test matrix

## Rollout/Rollback
Merge / revert

## Testing
CI on this PR

[PHPMNT-177]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ